### PR TITLE
Fix emscripten build

### DIFF
--- a/libLoam/c/ob-time.h
+++ b/libLoam/c/ob-time.h
@@ -9,6 +9,7 @@
 #include "libLoam/c/ob-retorts.h"
 
 #include <stdlib.h> /* for struct timeval */
+#include <sys/time.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When compiling with emcc, struct timeval is defined in sys/time.h.

Without this change, compiling with emcc results in errors like:

```console
In file included from /home/jshrake/code/c-plasma/plasma/libLoam/c/ob-time.c:8:
/home/jshrake/code/c-plasma/plasma/libLoam/c/ob-time.h:57:47: warning: declaration of 'struct timeval' will not be visible outside of this function [-Wvisibility]
   57 |                                  const struct timeval *tv);
      |                                               ^
/home/jshrake/code/c-plasma/plasma/libLoam/c/ob-time.c:55:6: error: conflicting types for 'ob_format_time'
   55 | void ob_format_time (char *buf, size_t bufsiz, const struct timeval *tv)
      |      ^
/home/jshrake/code/c-plasma/plasma/libLoam/c/ob-time.h:56:18: note: previous declaration is here
   56 | OB_LOAM_API void ob_format_time (char *buf, size_t bufsiz,
      |                  ^
/home/jshrake/code/c-plasma/plasma/libLoam/c/ob-time.c:91:33: warning: incompatible pointer types passing 'struct timeval *' to parameter of type 'const struct timeval *' [-Wincompatible-pointer-types]
   91 |   ob_format_time (buf, bufsize, &tv);
      |                                 ^~~
/home/jshrake/code/c-plasma/plasma/libLoam/c/ob-time.h:57:56: note: passing argument to parameter 'tv' here
   57 |                                  const struct timeval *tv);
      |                                                        ^
2 warnings and 1 error generated.
```