### PR TITLE
Fix infinite loop bug in ob_search_path()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 * Docker build [#3](https://github.com/zeugma-hamper/plasma/pull/3)
 
 * Documentation fixes/improvements [#4](https://github.com/zeugma-hamper/plasma/pull/4)
+
+* Fix infinite loop bug in `ob_search_path()` when `path` argument is an empty string [#5](https://github.com/zeugma-hamper/plasma/pull/5)

--- a/libLoam/c/ob-dirs.c
+++ b/libLoam/c/ob-dirs.c
@@ -589,6 +589,10 @@ ob_retort ob_search_path (const char *path, const char *filename,
   if (ob_is_explicit (filename))
     return do_callback (filename, func, vargies);
 
+  // avoid going into infinite loop on "while (*specp)" below!
+  if (path == NULL || path[0] == 0)
+    return OB_OK;
+
   size_t len = 2 + strlen (filename) + longest_component (path);
   char *scratch = (char *) malloc (len);
   if (!scratch)


### PR DESCRIPTION
If the `ob_search_path()` function is given an empty string as the `path` argument, it goes into an infinite loop.  This branch fixes that bug.

The implementation of `ob_search_path()` contains the comment:

```c
  // XXX: long, confusing, maybe break up into functions?
```

I'm not sure whether I wrote that comment, or someone else did, but it's true.  The code in `ob_search_path()` that I wrote 15-ish years ago was way too clever for my own good.  My present-day self doesn't understand it.

It would be good to make it more understandable, but I don't feel like tackling that today.  So this branch just fixes the bug when the path is an empty string.