### PR TITLE
Error handling for ob_strptime (also, rewritten and simplified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,10 @@
 
 * Improve source code formatting
   [#7](https://github.com/zeugma-hamper/plasma/pull/7)
+
+* Added new retort `OB_PARSE_ERROR`, and return it from
+  `ob_strptime()` when the input string is malformed.  (Previously,
+  `OB_OK` was being returned, even when the string could not be
+  parsed.)  Also, a general rewrite/cleanup/simplification of
+  `ob_strptime()`.  Added additional tests for `ob_strptime()`.
+  [#8](https://github.com/zeugma-hamper/plasma/pull/8)

--- a/libLoam/c/ob-retorts.c
+++ b/libLoam/c/ob-retorts.c
@@ -79,6 +79,7 @@ const char *ob_error_string_literal (ob_retort err)
       E (OB_NOT_FOUND);
       E (OB_NOTHING_TO_DO);
       E (OB_OK);
+      E (OB_PARSE_ERROR);
       E (OB_STOP);
       E (OB_UNKNOWN_ERR);
       E (OB_VERSION_MISMATCH);

--- a/libLoam/c/ob-retorts.h
+++ b/libLoam/c/ob-retorts.h
@@ -275,6 +275,11 @@ typedef int64 ob_retort;
 /** Illegal mixing of different versions of g-speak headers and shared libs. */
 #define OB_VERSION_MISMATCH OB_CONST_RETORT (-261)
 
+/**
+ * Unable to parse the given string.
+ */
+#define OB_PARSE_ERROR OB_CONST_RETORT (-270)
+
 // >>> add new error codes here <<<
 
 // success codes

--- a/libLoam/c/ob-time.c
+++ b/libLoam/c/ob-time.c
@@ -120,9 +120,20 @@ ob_retort ob_strptime (const char *s, float64 *seconds)
 
   struct tm fill;
   time_t tv;
-  strptime (datetime,
-            "%b " OB_STRFTIME_DAY_OF_MONTH_NO_LEADING_ZERO ", %Y %H:%M:%S",
-            &fill);
+
+  const char *ret =
+    strptime (datetime,
+              "%b " OB_STRFTIME_DAY_OF_MONTH_NO_LEADING_ZERO
+              ", %Y %H:%M:%S",
+              &fill);
+
+  if (ret == NULL)
+    {
+      free (s_cpy);
+      free (datetime);
+      return OB_PARSE_ERROR;
+    }
+
   fill.tm_isdst = -1; /* Not set by strptime.  Tells mktime() to check DST. */
   tv = mktime (&fill);
   free (s_cpy);

--- a/libLoam/c/ob-time.c
+++ b/libLoam/c/ob-time.c
@@ -8,10 +8,12 @@
 #include "libLoam/c/ob-time.h"
 #include "libLoam/c/ob-sys.h"
 #include "libLoam/c/ob-log.h"
+#include "libLoam/c/ob-util.h"
 
 #include <time.h>
 #include <stdio.h>
 #include <math.h>
+#include <ctype.h>
 
 #ifdef __APPLE__
 #include <mach/mach_time.h>
@@ -93,51 +95,41 @@ void ob_format_time_f (char *buf, size_t bufsize, const float64 seconds)
 
 ob_retort ob_strptime (const char *s, float64 *seconds)
 {
-  if (!s)
-    return OB_INVALID_ARGUMENT;
+  if (s == NULL || seconds == NULL)
+    return OB_ARGUMENT_WAS_NULL;
 
-  // since strptime (struct tm) does not support milliseconds, we must split
-  // the string into datetime and milliseconds
-  char *s_cpy = (char *) malloc (strlen (s) + 1);
-  strcpy (s_cpy, s);
-  char *delim;
-  size_t d_len, s_len = strlen (s) + 1;
-  for (d_len = 0, delim = s_cpy; d_len < s_len; d_len++, delim++)
-    {
-      if (delim[0] == '.')
-        break;
-    }
-
-  if (d_len == 0)
-    {
-      free (s_cpy);
-      return OB_INVALID_ARGUMENT;
-    }
-
-  char *datetime = (char *) malloc (d_len + 1);
-  strncpy (datetime, s_cpy, d_len);
-  float64 ms = atof (s_cpy + d_len);  // atof handily return 0.0 on error
+  const char *fmt =
+    "%b " OB_STRFTIME_DAY_OF_MONTH_NO_LEADING_ZERO ", %Y %H:%M:%S";
 
   struct tm fill;
-  time_t tv;
+  OB_CLEAR (fill);
 
-  const char *ret =
-    strptime (datetime,
-              "%b " OB_STRFTIME_DAY_OF_MONTH_NO_LEADING_ZERO
-              ", %Y %H:%M:%S",
-              &fill);
+  /* Parse the date and time up to the decimal point.
+   * (strptime only parses a whole number of seconds) */
+  char *endptr = strptime (s, fmt, &fill);
+  if (endptr == NULL)
+    return OB_PARSE_ERROR;
 
-  if (ret == NULL)
-    {
-      free (s_cpy);
-      free (datetime);
-      return OB_PARSE_ERROR;
-    }
+  float64 ms = 0.0;
+
+  /* Parse the fractional number of seconds, if any. */
+  if (*endptr == '.')
+    ms = strtod (endptr, &endptr);
+
+  if (endptr == NULL)
+    return OB_PARSE_ERROR;
+
+  /* Allow trailing whitespace */
+  while (isspace (*endptr))
+    endptr++;
+
+  /* If there is anything left over other than whitespace,
+   * call it an error. */
+  if (*endptr != 0)
+    return OB_PARSE_ERROR;
 
   fill.tm_isdst = -1; /* Not set by strptime.  Tells mktime() to check DST. */
-  tv = mktime (&fill);
-  free (s_cpy);
-  free (datetime);
+  time_t tv = mktime (&fill);
 
   if (tv == -1)
     return ob_errno_to_retort (errno);

--- a/libLoam/c/ob-time.h
+++ b/libLoam/c/ob-time.h
@@ -52,6 +52,10 @@ OB_LOAM_API ob_retort ob_micro_sleep (unt32 micro_seconds);
  * plus one byte for a nul terminator, plus one extra byte needed
  * internally, or the result is undefined.
  * 80 bytes is a safe output buffer size.
+ *
+ * \note Although \a tv is in UTC, the string representation
+ * is in local time.  Therefore, the current time zone is used
+ * implicitly.
  */
 OB_LOAM_API void ob_format_time (char *buf, size_t bufsiz,
                                  const struct timeval *tv);
@@ -59,6 +63,10 @@ OB_LOAM_API void ob_format_time (char *buf, size_t bufsiz,
 /**
  * Format the time, specified by \a seconds since Epoch Time, as a string
  * into \a buf (of length \a bufsiz).
+ *
+ * \note Although \a seconds is in UTC, the string representation
+ * is in local time.  Therefore, the current time zone is used
+ * implicitly.
  */
 OB_LOAM_API void ob_format_time_f (char *buf, size_t bufsiz,
                                    const float64 seconds);
@@ -74,6 +82,10 @@ OB_LOAM_API void ob_format_time_f (char *buf, size_t bufsiz,
  *     ob_format_time_f (ctime, sizeof (ctime), cur_time);
  *     ob_strptime (ctime, &echo_time);
  *     EXPECT_LT (cur_time - echo_time, 0.01);
+ *
+ * \note Although \a seconds is in UTC, the string representation
+ * is in local time.  Therefore, the current time zone is used
+ * implicitly.
  */
 OB_LOAM_API ob_retort ob_strptime (const char *s, float64 *seconds);
 

--- a/libLoam/c/tests/test-time.c
+++ b/libLoam/c/tests/test-time.c
@@ -7,15 +7,57 @@
 #include "libLoam/c/ob-time.h"
 #include "libLoam/c/ob-util.h"
 #include "libLoam/c/ob-log.h"
+#include "libLoam/c/ob-retorts.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <time.h>
+#include <math.h>
+
+static int num_failures = 0;
+
+typedef struct for_a_good_time_call
+{
+  char good_time[32];
+  char expected[32];
+} for_a_good_time_call;
+
+static const for_a_good_time_call good_times[] =
+  {
+    { "Dec 20, 2024 13:30:53.63 "   , "Dec 20, 2024 13:30:53.63 "    },
+    { "Dec 20, 2024 13:30:53.63"    , "Dec 20, 2024 13:30:53.63 "    },
+    { "Dec 20, 2024 13:30:53.631 "  , "Dec 20, 2024 13:30:53.63 "    },
+    { "Dec 20, 2024 13:30:53.631"   , "Dec 20, 2024 13:30:53.63 "    },
+    { "Dec 20, 2024 13:30:53.50 "   , "Dec 20, 2024 13:30:53.50 "    },
+    { "Dec 20, 2024 13:30:53.50"    , "Dec 20, 2024 13:30:53.50 "    },
+    { "Dec 20, 2024 13:30:53.5 "    , "Dec 20, 2024 13:30:53.50 "    },
+    { "Dec 20, 2024 13:30:53.5"     , "Dec 20, 2024 13:30:53.50 "    },
+    { "Dec 20, 2024 13:30:53 "      , "Dec 20, 2024 13:30:53.00 "    },
+    { "Dec 20, 2024 13:30:53"       , "Dec 20, 2024 13:30:53.00 "    },
+  };
+
+typedef struct for_a_bad_time_call
+{
+  char      bad_time[32];
+  ob_retort expected;
+} for_a_bad_time_call;
+
+static const for_a_bad_time_call bad_times[] =
+  {
+    { "Dec 32, 2024 13:30:53.63"    , OB_UNKNOWN_ERR },
+    { "Dec 20, 2024 25:30:53.63"    , OB_UNKNOWN_ERR },
+    { "Dec 20, 2024 13:30:xx.63"    , OB_UNKNOWN_ERR },
+    { "Dec 20, 2024 13:30:53.xx"    , OB_UNKNOWN_ERR },
+    { "Dec 20, 867-5309 13:30:53.63", OB_UNKNOWN_ERR },
+    { "Blob 20, 2024 13:30:53.63"   , OB_UNKNOWN_ERR },
+    { ".63"                         , OB_UNKNOWN_ERR },
+    { ""                            , OB_UNKNOWN_ERR },
+  };
 
 /* oddly, ob_format_time outputs a single trailing space. */
 static const char beg_of_time_s[] = "Jan 1, 1970 00:00:00.00 ";
-static float64 beg_of_time_sec = 0.0;
-struct timeval beg_of_time_tv (void)
+static const float64 beg_of_time_sec = 0.0;
+static struct timeval beg_of_time_tv (void)
 {
   struct timeval tv;
   tv.tv_sec = 0;
@@ -24,8 +66,8 @@ struct timeval beg_of_time_tv (void)
 }
 
 static const char rand_test_time_s[] = "Oct 31, 2016 16:20:42.09 ";
-static float64 rand_test_time_sec = 1477930842.099525;
-struct timeval rand_test_time_tv (void)
+static const float64 rand_test_time_sec = 1477930842.099525;
+static struct timeval rand_test_time_tv (void)
 {
   struct timeval tv;
   tv.tv_sec = 1477930842;
@@ -126,6 +168,27 @@ static void test_ob_format_time_f (void)
                 buf, expected_len);
 }
 
+static void print_passfail (bool good)
+{
+  if (good)
+    {
+      printf ("\033[32m\342\234\224\033[0m");
+    }
+  else
+    {
+      printf ("\033[91m\360\237\227\264\033[0m");
+      num_failures++;
+    }
+}
+
+static void print_test_string (const char *str)
+{
+  char buf[80];
+
+  snprintf (buf, sizeof (buf), "\"%.75s\"", str);
+  printf ("%-30s -> ", buf);
+}
+
 static void test_ob_strptime (void)
 {
   char ctime1[80];
@@ -137,8 +200,51 @@ static void test_ob_strptime (void)
 
   OB_DIE_ON_ERROR (ob_strptime (ctime1, &echo_time));
 
-  if ((cur_time - echo_time) > 0.01)
+  if (fabs (cur_time - echo_time) > 0.01)
     error_exit ("test_ob_strptime: %f != %f\n", cur_time, echo_time);
+
+  /* Test whether some known-good strings round-trip as expected */
+  size_t i;
+
+  for (i = 0; i < sizeof (good_times) / sizeof (good_times[0]); i++)
+    {
+      float64     secs = -1.0;
+      const char *good = good_times[i].good_time;
+
+      print_test_string (good);
+      ob_retort   tort = ob_strptime (good, &secs);
+
+      if (tort == OB_OK)
+        {
+          char buf[80];
+
+          ob_format_time_f (buf, sizeof (buf), secs);
+
+          print_passfail (0 == strcmp (buf, good_times[i].expected));
+          printf (" \"%s\"\n", buf);
+        }
+      else
+        {
+          const char *msg  = ob_error_string (tort);
+          print_passfail (false);
+          printf (" %s\n", msg);
+        }
+    }
+
+  /* Test whether some known-bad strings fail as expected */
+  for (i = 0; i < sizeof (bad_times) / sizeof (bad_times[0]); i++)
+    {
+      float64     secs = -1.0;
+      const char *bad  = bad_times[i].bad_time;
+
+      print_test_string (bad);
+
+      ob_retort   tort = ob_strptime (bad, &secs);
+      print_passfail (tort == bad_times[i].expected);
+
+      const char *msg  = ob_error_string (tort);
+      printf (" %s\n", msg);
+    }
 }
 
 int main (int argc, char **argv)
@@ -151,5 +257,5 @@ int main (int argc, char **argv)
   test_ob_format_time_f ();
   test_ob_strptime ();
 
-  return EXIT_SUCCESS;
+  return num_failures;
 }

--- a/libLoam/c/tests/test-time.c
+++ b/libLoam/c/tests/test-time.c
@@ -44,14 +44,14 @@ typedef struct for_a_bad_time_call
 
 static const for_a_bad_time_call bad_times[] =
   {
-    { "Dec 32, 2024 13:30:53.63"    , OB_UNKNOWN_ERR },
-    { "Dec 20, 2024 25:30:53.63"    , OB_UNKNOWN_ERR },
-    { "Dec 20, 2024 13:30:xx.63"    , OB_UNKNOWN_ERR },
-    { "Dec 20, 2024 13:30:53.xx"    , OB_UNKNOWN_ERR },
-    { "Dec 20, 867-5309 13:30:53.63", OB_UNKNOWN_ERR },
-    { "Blob 20, 2024 13:30:53.63"   , OB_UNKNOWN_ERR },
-    { ".63"                         , OB_UNKNOWN_ERR },
-    { ""                            , OB_UNKNOWN_ERR },
+    { "Dec 32, 2024 13:30:53.63"    , OB_PARSE_ERROR },
+    { "Dec 20, 2024 25:30:53.63"    , OB_PARSE_ERROR },
+    { "Dec 20, 2024 13:30:xx.63"    , OB_PARSE_ERROR },
+    { "Dec 20, 2024 13:30:53.xx"    , OB_PARSE_ERROR },
+    { "Dec 20, 867-5309 13:30:53.63", OB_PARSE_ERROR },
+    { "Blob 20, 2024 13:30:53.63"   , OB_PARSE_ERROR },
+    { ".63"                         , OB_PARSE_ERROR },
+    { ""                            , OB_PARSE_ERROR },
   };
 
 /* oddly, ob_format_time outputs a single trailing space. */


### PR DESCRIPTION
`ob_strptime()` was returning `OB_OK` when fed erroneous strings such as these:

```
Dec 32, 2024 13:30:53.63
Dec 20, 2024 25:30:53.63
Dec 20, 2024 13:30:xx.63
Dec 20, 2024 13:30:53.xx
Dec 20, 867-5309 13:30:53.63
Blob 20, 2024 13:30:53.63
```

This branch does the following:

* Checks the return value of `strptime()`, and returns a new retort, `OB_PARSE_ERROR`, if there was an error in `strptime()`.
* Enhances `test-time.c` to make sure that an error is returned by `ob_strptime()` for malformed input.
* Rewrites `ob_strptime()` to be simpler and easier to understand.  In particular, the old code was doing two `malloc()`s and making unnecessary copies of strings.  Also, it was searching for the decimal point explicitly, rather than taking advantage of the fact that `strptime()` will return a pointer to it.