### PR TITLE
Formatting 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Improve source code formatting
   [#7](https://github.com/zeugma-hamper/plasma/pull/7)
+  [#10](https://github.com/zeugma-hamper/plasma/pull/10)
 
 * Added new retort `OB_PARSE_ERROR`, and return it from
   `ob_strptime()` when the input string is malformed.  (Previously,

--- a/libLoam/c/ob-endian.h
+++ b/libLoam/c/ob-endian.h
@@ -34,7 +34,10 @@ static inline unt32 ob_swap32 (unt32 x)
 #ifdef OB_HAVE_GCC_BSWAP_BUILTINS
   return __builtin_bswap32 (x);
 #else
-  return ((x << 24) | ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00) | (x >> 24));
+  return (( x << 24)             |
+          ((x <<  8) & 0xff0000) |
+          ((x >>  8) & 0xff00)   |
+          ( x >> 24));
 #endif /* OB_HAVE_GCC_BSWAP_BUILTINS */
 }
 
@@ -49,12 +52,14 @@ static inline unt64 ob_swap64 (unt64 x)
   // Inspired by:
   // https://web.archive.org/web/20090805070309/http://blogs.sun.com/DanX/entry/optimizing_byte_swapping_for_fun
   // (see "I rewrote it to this a less elegant, but faster implementation:")
-  return ((x << 56) | ((x << 40) & OB_CONST_U64 (0xff000000000000))
-          | ((x << 24) & OB_CONST_U64 (0xff0000000000))
-          | ((x << 8) & OB_CONST_U64 (0xff00000000))
-          | ((x >> 8) & OB_CONST_U64 (0xff000000))
-          | ((x >> 24) & OB_CONST_U64 (0xff0000))
-          | ((x >> 40) & OB_CONST_U64 (0xff00)) | (x >> 56));
+  return (( x << 56)                                    |
+          ((x << 40) & OB_CONST_U64 (0xff000000000000)) |
+          ((x << 24) & OB_CONST_U64 (0xff0000000000))   |
+          ((x <<  8) & OB_CONST_U64 (0xff00000000))     |
+          ((x >>  8) & OB_CONST_U64 (0xff000000))       |
+          ((x >> 24) & OB_CONST_U64 (0xff0000))         |
+          ((x >> 40) & OB_CONST_U64 (0xff00))           |
+          ( x >> 56));
 #endif /* OB_HAVE_GCC_BSWAP_BUILTINS */
 }
 

--- a/libPlasma/c/pool.h
+++ b/libPlasma/c/pool.h
@@ -687,7 +687,8 @@ OB_PLASMA_API ob_retort pool_next (pool_hose ph, protein *ret_prot,
  * Returns POOL_AWAIT_TIMEDOUT if no protein arrived before the
  * timeout expired.
  */
-OB_PLASMA_API ob_retort pool_await_next (pool_hose ph, pool_timestamp timeout,
+OB_PLASMA_API ob_retort pool_await_next (pool_hose ph,
+                                         pool_timestamp timeout,
                                          protein *ret_prot,
                                          pool_timestamp *ret_ts,
                                          int64 *ret_index);
@@ -719,7 +720,8 @@ OB_PLASMA_API ob_retort pool_hose_wake_up (pool_hose ph);
  * Retrieve the protein at the pool hose's index. If no protein
  * is available, this function returns POOL_NO_SUCH_PROTEIN.
  */
-OB_PLASMA_API ob_retort pool_curr (pool_hose ph, protein *ret_prot,
+OB_PLASMA_API ob_retort pool_curr (pool_hose ph,
+                                   protein *ret_prot,
                                    pool_timestamp *ret_ts);
 
 /**
@@ -728,8 +730,10 @@ OB_PLASMA_API ob_retort pool_curr (pool_hose ph, protein *ret_prot,
  * protein before the current one is available, we return
  * POOL_NO_SUCH_PROTEIN.
  */
-OB_PLASMA_API ob_retort pool_prev (pool_hose ph, protein *ret_prot,
-                                   pool_timestamp *ret_ts, int64 *ret_index);
+OB_PLASMA_API ob_retort pool_prev (pool_hose ph,
+                                   protein *ret_prot,
+                                   pool_timestamp *ret_ts,
+                                   int64 *ret_index);
 
 /**
  * Search forward in the pool for a protein with a descrip matching
@@ -741,9 +745,11 @@ OB_PLASMA_API ob_retort pool_prev (pool_hose ph, protein *ret_prot,
  * protein_search().  Therefore, if \a search is a list, performs
  * slaw_list_gapsearch().  Otherwise, performs slaw_list_find().
  */
-OB_PLASMA_API ob_retort pool_probe_frwd (pool_hose ph, bslaw search,
+OB_PLASMA_API ob_retort pool_probe_frwd (pool_hose ph,
+                                         bslaw search,
                                          protein *ret_prot,
-                                         pool_timestamp *ret_ts, int64 *idx);
+                                         pool_timestamp *ret_ts,
+                                         int64 *idx);
 
 /**
  * The same as pool_probe_frwd(), but wait if necessary.  See
@@ -752,7 +758,8 @@ OB_PLASMA_API ob_retort pool_probe_frwd (pool_hose ph, bslaw search,
  * \note \a timeout is overall, and does not restart when a non-matching
  * protein is found.
  */
-OB_PLASMA_API ob_retort pool_await_probe_frwd (pool_hose ph, bslaw search,
+OB_PLASMA_API ob_retort pool_await_probe_frwd (pool_hose ph,
+                                               bslaw search,
                                                pool_timestamp timeout,
                                                protein *ret_prot,
                                                pool_timestamp *ret_ts,
@@ -765,9 +772,11 @@ OB_PLASMA_API ob_retort pool_await_probe_frwd (pool_hose ph, bslaw search,
  * On success (OB_OK), the hose's current index will be *idx.
  * On failure (non-OB_OK), the hose's current index will remain unchanged.
  */
-OB_PLASMA_API ob_retort pool_probe_back (pool_hose ph, bslaw search,
+OB_PLASMA_API ob_retort pool_probe_back (pool_hose ph,
+                                         bslaw search,
                                          protein *ret_prot,
-                                         pool_timestamp *ret_ts, int64 *idx);
+                                         pool_timestamp *ret_ts,
+                                         int64 *idx);
 
 /**
  * Fetch all or some of one or more proteins.  The \a ops array,
@@ -785,8 +794,11 @@ OB_PLASMA_API ob_retort pool_probe_back (pool_hose ph, bslaw search,
  * occurs, they will be set to a negative number-- specifically,
  * the retort indicating the error.
  */
-OB_PLASMA_API void pool_fetch (pool_hose ph, pool_fetch_op *ops, int64 nops,
-                               int64 *oldest_idx_out, int64 *newest_idx_out);
+OB_PLASMA_API void pool_fetch (pool_hose ph,
+                               pool_fetch_op *ops,
+                               int64 nops,
+                               int64 *oldest_idx_out,
+                               int64 *newest_idx_out);
 
 /**
  * Same as pool_fetch(), but can optionally clamp the idx values to within
@@ -795,8 +807,11 @@ OB_PLASMA_API void pool_fetch (pool_hose ph, pool_fetch_op *ops, int64 nops,
  * an error.)  If clamped, the idx member in \a ops will be changed to
  * reflect the index of the protein actually retrieved.
  */
-OB_PLASMA_API void pool_fetch_ex (pool_hose ph, pool_fetch_op *ops, int64 nops,
-                                  int64 *oldest_idx_out, int64 *newest_idx_out,
+OB_PLASMA_API void pool_fetch_ex (pool_hose ph,
+                                  pool_fetch_op *ops,
+                                  int64 nops,
+                                  int64 *oldest_idx_out,
+                                  int64 *newest_idx_out,
                                   bool clamp);
 //@}
 


### PR DESCRIPTION
* Reformat some function prototypes to have one argument per line; easier to read.
* Reformat some complicated masking and shifting in byte swap functions to look a little cleaner.