### PR TITLE
Adding feature-detection to simplify supporting older and newer systems (esp. macos).  Adding some socket settings for tuning the tcp pool server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,23 @@ obj-*-linux-*/
 
 # Common cmake dirs
 build
+
+# Build artifacts
+.ninja_deps
+.ninja_log
+*.backup
+build_bu/
+obenv
+yotest
+
+# CMake generated files
+CTestTestfile.cmake
+CTestCustom.cmake
+OblongConfig.cmake
+
+# Generated directories
+**/generated/
+libProtist/
+
+# Generated scripts
+libPlasma/ruby/gembuild/build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,34 @@ cmake_minimum_required (VERSION 3.6.2)
 
 project(g-speak CXX C)
 
-# Select C++11 dialect
-set(CMAKE_CXX_STANDARD 11)
+# Compatibility options
+option(PLASMA_LEGACY_MODE "Build for compatibility with older systems" OFF)
+option(PLASMA_ENABLE_TCP_OPTIMIZATIONS "Enable TCP performance optimizations" ON)
+option(PLASMA_ENABLE_LARGE_TRANSFER_LOGGING "Enable logging for transfers >1MB" ON)
+
+# Auto-detect if legacy mode needed
+if(NOT DEFINED PLASMA_LEGACY_MODE)
+    # Check compiler version
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
+        set(PLASMA_LEGACY_MODE ON)
+        message(STATUS "GCC < 5.0 detected - enabling legacy compatibility mode")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.4")
+        set(PLASMA_LEGACY_MODE ON)
+        message(STATUS "Clang < 3.4 detected - enabling legacy compatibility mode")
+    elseif(DEFINED ENV{PLASMA_LEGACY_BUILD})
+        set(PLASMA_LEGACY_MODE ON)
+        message(STATUS "PLASMA_LEGACY_BUILD environment variable set - enabling legacy compatibility mode")
+    endif()
+endif()
+
+# Select C++ dialect based on mode
+if(PLASMA_LEGACY_MODE)
+    set(CMAKE_CXX_STANDARD 11)
+    message(STATUS "Building in legacy compatibility mode (C++11)")
+else()
+    set(CMAKE_CXX_STANDARD 17)
+    message(STATUS "Building with modern features (C++17)")
+endif()
 set(CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -16,6 +42,7 @@ INCLUDE("ObBoilerplate")
 INCLUDE("ObGenerateProject")
 # Short name
 SET(TOP_TEMPLATE ${CMAKE_SOURCE_DIR}/samples/obi-template)
+
 
 set(top_srcdir "${g-speak_SOURCE_DIR}")
 set(abs_top_srcdir "${g-speak_SOURCE_DIR}")
@@ -97,6 +124,44 @@ add_definitions("-DBOOST_SYSTEM_NO_DEPRECATED")
 
 INCLUDE(CheckIncludeFileCXX)
 INCLUDE(CheckIncludeFile)
+INCLUDE(CheckCXXSourceCompiles)
+INCLUDE(CheckSymbolExists)
+INCLUDE(CheckCXXCompilerFlag)
+
+# Feature detection for compatibility
+if(PLASMA_LEGACY_MODE)
+    set(PLASMA_LEGACY_BUILD 1)
+endif()
+
+# Check for C++ features
+check_cxx_source_compiles("
+    #include <random>
+    #include <algorithm>
+    #include <vector>
+    int main() { 
+        std::vector<int> v = {1,2,3,4,5};
+        std::mt19937 gen;
+        std::shuffle(v.begin(), v.end(), gen);
+        return 0; 
+    }" HAVE_STD_SHUFFLE)
+
+check_cxx_source_compiles("
+    #include <random>
+    int main() { 
+        std::mt19937 gen;
+        return 0; 
+    }" HAVE_STD_MT19937)
+
+# Check for TCP features
+if(NOT WIN32)
+    check_symbol_exists(TCP_USER_TIMEOUT "netinet/tcp.h" HAVE_TCP_USER_TIMEOUT)
+    check_symbol_exists(TCP_KEEPINTVL "netinet/tcp.h" HAVE_TCP_KEEPINTVL)
+    check_symbol_exists(TCP_KEEPIDLE "netinet/tcp.h" HAVE_TCP_KEEPIDLE)
+endif()
+
+# Configure plasma_config.h
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plasma_config.h.in 
+               ${CMAKE_CURRENT_BINARY_DIR}/plasma_config.h)
 if (UNIX)
   set(OPENSSL_LIBRARIES "-lssl -lcrypto")
   set(OPENSSL_FOUND TRUE)
@@ -265,6 +330,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DQUOTED_PREFIX=\\\"${CMAKE_INSTALL_PREFIX}\
 
 # Let source files use top-relative include path
 include_directories(${g-speak_BINARY_DIR})
+# Include directory for generated plasma_config.h
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${g-speak_SOURCE_DIR})
 include_directories(${g-speak_SOURCE_DIR}/system)
 include_directories(SYSTEM ${g-speak_SOURCE_DIR}/gtest/include)

--- a/libLoam/c++/CMakeLists.txt
+++ b/libLoam/c++/CMakeLists.txt
@@ -125,6 +125,12 @@ ObGeneratePC (
 
 include_directories(${Loam++_SOURCE_DIR})
 
+# Add ICU include directories
+if(APPLE)
+  set(ICU_ROOT /opt/homebrew/opt/icu4c)
+  include_directories(${ICU_ROOT}/include)
+endif()
+
 add_library(Loam++ ${LIBRARY_TYPE} ${Loam++_SOURCES})
 target_link_libraries(Loam++ ${Loam++_LINK_LIBS})
 set_target_properties(Loam++ PROPERTIES

--- a/libLoam/c++/tests/FatherTimeTest.cpp
+++ b/libLoam/c++/tests/FatherTimeTest.cpp
@@ -3,11 +3,14 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include "plasma_config.h"
 #include "libLoam/c/ob-rand.h"
 #include "libLoam/c/ob-time.h"
 #include "libLoam/c/ob-util.h"
 #include "libLoam/c++/FatherTime.h"
 #include "libLoam/c++/ObTrove.h"
+
+#include <random>
 
 using namespace oblong::loam;
 
@@ -51,7 +54,12 @@ static void waste_time ()
   for (int i = 0; i < enuf; i++)
     vals[i] = i;
 
+#ifdef HAVE_STD_SHUFFLE
+  std::shuffle(vals + 0, vals + enuf, std::mt19937{std::random_device{}()});
+#else
   std::random_shuffle (vals + 0, vals + enuf);
+#endif
+
   ObTrove<int32> trov (vals, enuf);
   trov.Sort (cmp);
 

--- a/libLoam/c++/tests/ObRetortTest.cpp
+++ b/libLoam/c++/tests/ObRetortTest.cpp
@@ -1,6 +1,7 @@
 
 /* (c)  oblong industries */
 
+#include "plasma_config.h"
 #include "libLoam/c/ob-rand.h"
 #include "libLoam/c/ob-sys.h"
 #include "libLoam/c/ob-util.h"
@@ -18,6 +19,8 @@
 
 #include <algorithm>
 #include <unordered_set>
+
+#include <random>
 
 
 using namespace oblong::loam;
@@ -335,7 +338,12 @@ TEST (ObRetortTest, RetortsInASet)
   std::vector<ObRetort> vec;
   vec.resize (st.size ());
   std::copy (st.begin (), st.end (), vec.begin ());
+#ifdef HAVE_STD_SHUFFLE
+  std::shuffle(vec.begin(), vec.end(), std::mt19937{std::random_device{}()});
+#else
   std::random_shuffle (vec.begin (), vec.end ());
+#endif
+
 
   for (std::vector<ObRetort>::iterator it = vec.begin (); it != vec.end ();
        it++)

--- a/libPlasma/c++/Slaw.cpp
+++ b/libPlasma/c++/Slaw.cpp
@@ -5,6 +5,9 @@
 #include "SlawIterator.h"
 #include "libPlasma/c++/PlasmaStreams.h"
 
+
+#include "compat.h"
+
 #include <libPlasma/c/protein.h>
 #include <libPlasma/c/slaw-io.h>
 
@@ -1091,3 +1094,5 @@ static const char *plasmaxx_error_string (ob_retort err)
 
 static ob_retort dummy_plasmaxx OB_UNUSED =
   ob_add_error_names (plasmaxx_error_string);
+
+PLASMA_RESTORE_WARNINGS

--- a/libPlasma/c++/SlawList.cpp
+++ b/libPlasma/c++/SlawList.cpp
@@ -9,6 +9,8 @@
 
 #include <libPlasma/c/protein.h>
 
+#include "compat.h"
+
 #include <functional>
 #include <algorithm>
 #include <ostream>
@@ -296,3 +298,5 @@ void SlawList::Spew (OStreamReference os) const
 }
 }
 }  // namespace oblong::plasma::detail
+
+PLASMA_RESTORE_WARNINGS

--- a/libPlasma/c++/compat.h
+++ b/libPlasma/c++/compat.h
@@ -1,0 +1,112 @@
+#ifndef PLASMA_COMPAT_H
+#define PLASMA_COMPAT_H
+
+#include "plasma_config.h"
+#include <functional>
+#include <algorithm>
+
+// Define macros to check for specific standard library implementations
+#if defined(__GLIBCXX__)
+  #define PLASMA_USING_LIBSTDCXX
+#elif defined(_LIBCPP_VERSION)
+  #define PLASMA_USING_LIBCXX
+#elif defined(_MSC_VER)
+  #define PLASMA_USING_MSVC
+#endif
+
+// Check if deprecated functions are available
+// For GCC/libstdc++, these functions are still available even in C++17 mode
+// but are marked as deprecated
+#ifdef PLASMA_LEGACY_BUILD
+  // In legacy mode, we know we're using C++11 where these are available
+  #define PLASMA_HAS_DEPRECATED_FUNCTIONAL 1
+#elif defined(PLASMA_USING_LIBSTDCXX) && defined(_GLIBCXX_FUNCTIONAL)
+  // libstdc++ still has these functions, just deprecated
+  #define PLASMA_HAS_DEPRECATED_FUNCTIONAL 1
+#elif defined(PLASMA_USING_LIBCXX) && __cplusplus >= 201703L
+  // libc++ removes them in C++17
+  #define PLASMA_HAS_DEPRECATED_FUNCTIONAL 0
+#elif defined(PLASMA_USING_MSVC) && _MSVC_LANG >= 201703L
+  // MSVC removes them in C++17
+  #define PLASMA_HAS_DEPRECATED_FUNCTIONAL 0
+#else
+  // Default: assume they're available pre-C++17
+  #define PLASMA_HAS_DEPRECATED_FUNCTIONAL (__cplusplus < 201703L)
+#endif
+
+#if PLASMA_HAS_DEPRECATED_FUNCTIONAL
+  // Use standard library functions but suppress deprecation warnings
+  #if defined(__GNUC__) || defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #elif defined(_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4996)
+  #endif
+#else
+  // Provide replacements for removed functions
+  
+  namespace std {
+    // Custom implementation of bind2nd
+    template<typename BinaryOp, typename T>
+    class plasma_binder2nd {
+        BinaryOp op;
+        T value;
+    public:
+        plasma_binder2nd(const BinaryOp& x, const T& y) : op(x), value(y) {}
+        
+        template<typename Arg>
+        auto operator()(Arg&& arg) const 
+            -> decltype(op(std::forward<Arg>(arg), value)) {
+            return op(std::forward<Arg>(arg), value);
+        }
+    };
+    
+    template<typename BinaryOp, typename T>
+    plasma_binder2nd<BinaryOp, T> bind2nd(const BinaryOp& op, const T& value) {
+        return plasma_binder2nd<BinaryOp, T>(op, value);
+    }
+    
+    // Custom implementation of mem_fun_ref for const member functions
+    template<typename S, typename T, typename A>
+    class plasma_const_mem_fun1_ref_t {
+        S (T::*pmf)(A) const;
+    public:
+        explicit plasma_const_mem_fun1_ref_t(S (T::*p)(A) const) : pmf(p) {}
+        S operator()(const T& p, A x) const { return (p.*pmf)(x); }
+    };
+    
+    template<typename S, typename T>
+    class plasma_const_mem_fun_ref_t {
+        S (T::*pmf)() const;
+    public:
+        explicit plasma_const_mem_fun_ref_t(S (T::*p)() const) : pmf(p) {}
+        S operator()(const T& p) const { return (p.*pmf)(); }
+    };
+    
+    template<typename S, typename T, typename A>
+    plasma_const_mem_fun1_ref_t<S, T, A> mem_fun_ref(S (T::*f)(A) const) {
+        return plasma_const_mem_fun1_ref_t<S, T, A>(f);
+    }
+    
+    template<typename S, typename T>
+    plasma_const_mem_fun_ref_t<S, T> mem_fun_ref(S (T::*f)() const) {
+        return plasma_const_mem_fun_ref_t<S, T>(f);
+    }
+  }
+#endif
+
+// Macro to restore warnings at the end of files
+#if PLASMA_HAS_DEPRECATED_FUNCTIONAL
+  #if defined(__GNUC__) || defined(__clang__)
+    #define PLASMA_RESTORE_WARNINGS _Pragma("GCC diagnostic pop")
+  #elif defined(_MSC_VER)
+    #define PLASMA_RESTORE_WARNINGS __pragma(warning(pop))
+  #else
+    #define PLASMA_RESTORE_WARNINGS
+  #endif
+#else
+  #define PLASMA_RESTORE_WARNINGS
+#endif
+
+#endif // PLASMA_COMPAT_H

--- a/libPlasma/c/CMakeLists.txt
+++ b/libPlasma/c/CMakeLists.txt
@@ -127,6 +127,12 @@ ObGeneratePC (
 include_directories(${Loam_SOURCE_DIR})
 include_directories(${Plasma_SOURCE_DIR})
 
+# Add ICU include directories
+if(APPLE)
+  set(ICU_ROOT /opt/homebrew/opt/icu4c)
+  include_directories(${ICU_ROOT}/include)
+endif()
+
 add_library(Plasma ${LIBRARY_TYPE} ${Plasma_SOURCES})
 target_link_libraries(Plasma ${Plasma_LINK_LIBS})
 set_target_properties(Plasma PROPERTIES

--- a/libPlasma/c/pool_net.c
+++ b/libPlasma/c/pool_net.c
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <assert.h>
 
+#include "plasma_config.h"
 #include "libLoam/c/ob-sys.h"
 #include "libLoam/c/ob-endian.h"
 #include "libLoam/c/ob-log.h"
@@ -333,6 +334,15 @@ static ob_retort _pool_net_send_op (pool_net_data *net, int op_num,
       return pret;
     }
 
+#ifdef PLASMA_ENABLE_LARGE_TRANSFER_LOGGING
+  // Log large protein sends
+  if (len > PLASMA_LARGE_TRANSFER_THRESHOLD)
+    {
+      ob_log (OBLV_INFO, 0x20106002, "Sending large protein: %lld bytes (%.2f MB) for op %d\n",
+              (long long) len, len / (1024.0 * 1024.0), op_num);
+    }
+#endif
+
   pret = net->send_nbytes (net->connfd, op_prot, len, *net->wakeup_handle_loc);
 
   protein_free (op_prot);
@@ -364,6 +374,15 @@ ob_retort pool_net_recv_op (pool_net_data *net, int *op_num, protein *ret_prot)
   // Avoid DoS or bug due to unrealistic length
   if (len > MAX_SLAW_SIZE)
     return POOL_PROTOCOL_ERROR;
+
+#ifdef PLASMA_ENABLE_LARGE_TRANSFER_LOGGING
+  // Log large protein receives
+  if (len > PLASMA_LARGE_TRANSFER_THRESHOLD)
+    {
+      ob_log (OBLV_INFO, 0x20106003, "Receiving large protein: %llu bytes (%.2f MB)\n",
+              (unsigned long long) len, len / (1024.0 * 1024.0));
+    }
+#endif
 
   // Now we can allocate the right amount of space for the protein
   char *raw_prot = (char *) malloc (len);

--- a/libPlasma/c/pool_tcp.c
+++ b/libPlasma/c/pool_tcp.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <errno.h>
+#include "plasma_config.h"
 #include "libLoam/c/ob-sys.h"
 #include "libLoam/c/ob-log.h"
 #include "libLoam/c/ob-file.h"
@@ -25,6 +26,9 @@
 #include "libPlasma/c/protein.h"
 #define EINTR_WANT_CONNECT 1
 #include "libPlasma/c/eintr-helper.h"
+#ifndef _MSC_VER
+#include <netinet/tcp.h>
+#endif
 
 #ifdef _MSC_VER
 
@@ -681,6 +685,64 @@ ob_retort ob_common_sockopts (ob_sock_t fd)
                          ob_sockmsg ());
       return POOL_SOCK_BADTH;
     }
+
+#ifdef PLASMA_ENABLE_TCP_OPTIMIZATIONS
+#ifndef _MSC_VER
+  // Increase socket buffer sizes for large transfers
+  int bufsize = PLASMA_TCP_BUFFER_SIZE;
+  if (setsockopt (fd, SOL_SOCKET, SO_RCVBUF, EVIL_SOCKOPT_CAST (&bufsize),
+                  sizeof (bufsize))
+      != 0)
+    {
+      OB_LOG_WARNING_CODE (0x20108026, "setsockopt/SO_RCVBUF: '%s' (continuing anyway)\n",
+                           ob_sockmsg ());
+    }
+  
+  if (setsockopt (fd, SOL_SOCKET, SO_SNDBUF, EVIL_SOCKOPT_CAST (&bufsize),
+                  sizeof (bufsize))
+      != 0)
+    {
+      OB_LOG_WARNING_CODE (0x20108027, "setsockopt/SO_SNDBUF: '%s' (continuing anyway)\n",
+                           ob_sockmsg ());
+    }
+
+#ifdef HAVE_TCP_USER_TIMEOUT
+  // Set TCP timeout for large transfers
+  int timeout_ms = PLASMA_TCP_TIMEOUT_MS;
+  if (setsockopt (fd, IPPROTO_TCP, TCP_USER_TIMEOUT, EVIL_SOCKOPT_CAST (&timeout_ms),
+                  sizeof (timeout_ms))
+      != 0)
+    {
+      OB_LOG_WARNING_CODE (0x20108028, "setsockopt/TCP_USER_TIMEOUT: '%s' (continuing anyway)\n",
+                           ob_sockmsg ());
+    }
+#endif
+
+#ifdef HAVE_TCP_KEEPINTVL
+  // Reduce keepalive interval to 30 seconds
+  int keepintvl = 30;
+  if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, EVIL_SOCKOPT_CAST (&keepintvl),
+                  sizeof (keepintvl))
+      != 0)
+    {
+      OB_LOG_WARNING_CODE (0x20108029, "setsockopt/TCP_KEEPINTVL: '%s' (continuing anyway)\n",
+                           ob_sockmsg ());
+    }
+#endif
+
+#ifdef HAVE_TCP_KEEPIDLE
+  // Start keepalive after 60 seconds of idle
+  int keepidle = 60;
+  if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, EVIL_SOCKOPT_CAST (&keepidle),
+                  sizeof (keepidle))
+      != 0)
+    {
+      OB_LOG_WARNING_CODE (0x2010802a, "setsockopt/TCP_KEEPIDLE: '%s' (continuing anyway)\n",
+                           ob_sockmsg ());
+    }
+#endif
+#endif // !_MSC_VER
+#endif // PLASMA_ENABLE_TCP_OPTIMIZATIONS
 
   return ob_nosigpipe_sockopt (fd);
 }

--- a/libPlasma/c/pool_tcp.c
+++ b/libPlasma/c/pool_tcp.c
@@ -34,9 +34,9 @@
 #endif
 
 // Rate limiting for socket close warnings
-static ob_atomic_int64 last_close_warning_time = 0;
-static ob_atomic_int64 close_warning_count = 0;
-static const int64 WARNING_THROTTLE_MS = 5000;  // Only log every 5 seconds
+static unt64 last_close_warning_time = 0;
+static unt64 close_warning_count = 0;
+static const unt64 WARNING_THROTTLE_MS = 5000 * OB_MILLI_TIME;  // 5 seconds
 
 #ifdef _MSC_VER
 
@@ -199,21 +199,22 @@ ob_retort pool_tcp_send_nbytes (ob_sock_t sock, const void *buf, size_t len,
           // it's likely the other end closed the socket for some reason
           if (nwritten == -1 && erryes == EPIPE)
             {
-              ob_atomic_int64_add(&close_warning_count, 1);
-              int64 now = ob_current_time();
-              int64 last = ob_atomic_int64_read(&last_close_warning_time);
+              close_warning_count++;
+              unt64 now = ob_current_time();
               
-              if (now - last > WARNING_THROTTLE_MS * OB_MILLI_TIME)
+              if (now - last_close_warning_time > WARNING_THROTTLE_MS)
                 {
                   char sock_info[256];
                   get_socket_info(sock, sock_info, sizeof(sock_info));
-                  int64 count = ob_atomic_int64_swap(&close_warning_count, 0);
+                  unt64 count = close_warning_count;
+                  close_warning_count = 0;
                   
                   if (count > 1)
                     {
                       OB_LOG_WARNING_CODE (0x20108027,
-                                           "socket was closed unexpectedly %s (occurred %lld times in last %d seconds)",
-                                           sock_info, (long long)count, WARNING_THROTTLE_MS/1000);
+                                           "socket was closed unexpectedly %s (occurred %llu times in last %d seconds)",
+                                           sock_info, (unsigned long long)count, 
+                                           (int)(WARNING_THROTTLE_MS / OB_MILLI_TIME / 1000));
                     }
                   else
                     {
@@ -221,7 +222,7 @@ ob_retort pool_tcp_send_nbytes (ob_sock_t sock, const void *buf, size_t len,
                                            "socket was closed unexpectedly %s",
                                            sock_info);
                     }
-                  ob_atomic_int64_set(&last_close_warning_time, now);
+                  last_close_warning_time = now;
                 }
               pret = POOL_UNEXPECTED_CLOSE;
             }
@@ -311,21 +312,22 @@ ob_retort pool_tcp_recv_nbytes (ob_sock_t sock, void *buf, size_t len,
           // it's likely the other end closed the socket for some reason
           if (nread == 0)
             {
-              ob_atomic_int64_add(&close_warning_count, 1);
-              int64 now = ob_current_time();
-              int64 last = ob_atomic_int64_read(&last_close_warning_time);
+              close_warning_count++;
+              unt64 now = ob_current_time();
               
-              if (now - last > WARNING_THROTTLE_MS * OB_MILLI_TIME)
+              if (now - last_close_warning_time > WARNING_THROTTLE_MS)
                 {
                   char sock_info[256];
                   get_socket_info(sock, sock_info, sizeof(sock_info));
-                  int64 count = ob_atomic_int64_swap(&close_warning_count, 0);
+                  unt64 count = close_warning_count;
+                  close_warning_count = 0;
                   
                   if (count > 1)
                     {
                       OB_LOG_WARNING_CODE (0x20108028,
-                                           "socket was closed unexpectedly %s (occurred %lld times in last %d seconds)",
-                                           sock_info, (long long)count, WARNING_THROTTLE_MS/1000);
+                                           "socket was closed unexpectedly %s (occurred %llu times in last %d seconds)",
+                                           sock_info, (unsigned long long)count,
+                                           (int)(WARNING_THROTTLE_MS / OB_MILLI_TIME / 1000));
                     }
                   else
                     {
@@ -333,7 +335,7 @@ ob_retort pool_tcp_recv_nbytes (ob_sock_t sock, void *buf, size_t len,
                                            "socket was closed unexpectedly %s",
                                            sock_info);
                     }
-                  ob_atomic_int64_set(&last_close_warning_time, now);
+                  last_close_warning_time = now;
                 }
               pret = POOL_UNEXPECTED_CLOSE;
             }

--- a/libPlasma/c/pool_tcp.c
+++ b/libPlasma/c/pool_tcp.c
@@ -28,6 +28,9 @@
 #include "libPlasma/c/eintr-helper.h"
 #ifndef _MSC_VER
 #include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #endif
 
 #ifdef _MSC_VER
@@ -39,6 +42,87 @@
 #define winsock_shutdown()
 
 #endif
+
+/// Helper function to get socket address info for logging
+static void get_socket_info (ob_sock_t sock, char *buf, size_t buflen)
+{
+#ifndef _MSC_VER
+  struct sockaddr_storage local_addr, peer_addr;
+  socklen_t addrlen = sizeof(local_addr);
+  
+  buf[0] = '\0';
+  
+  // Get local address
+  if (getsockname(sock, (struct sockaddr *)&local_addr, &addrlen) == 0)
+    {
+      char local_str[INET6_ADDRSTRLEN + 16];  // IP + port
+      char peer_str[INET6_ADDRSTRLEN + 16];
+      
+      // Format local address
+      if (local_addr.ss_family == AF_INET)
+        {
+          struct sockaddr_in *addr4 = (struct sockaddr_in *)&local_addr;
+          char ip[INET_ADDRSTRLEN];
+          inet_ntop(AF_INET, &addr4->sin_addr, ip, sizeof(ip));
+          snprintf(local_str, sizeof(local_str), "%s:%d", ip, ntohs(addr4->sin_port));
+        }
+      else if (local_addr.ss_family == AF_INET6)
+        {
+          struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&local_addr;
+          char ip[INET6_ADDRSTRLEN];
+          inet_ntop(AF_INET6, &addr6->sin6_addr, ip, sizeof(ip));
+          snprintf(local_str, sizeof(local_str), "[%s]:%d", ip, ntohs(addr6->sin6_port));
+        }
+      else
+        {
+          snprintf(local_str, sizeof(local_str), "<unknown family %d>", local_addr.ss_family);
+        }
+      
+      // Get peer address
+      addrlen = sizeof(peer_addr);
+      if (getpeername(sock, (struct sockaddr *)&peer_addr, &addrlen) == 0)
+        {
+          // Format peer address
+          if (peer_addr.ss_family == AF_INET)
+            {
+              struct sockaddr_in *addr4 = (struct sockaddr_in *)&peer_addr;
+              char ip[INET_ADDRSTRLEN];
+              inet_ntop(AF_INET, &addr4->sin_addr, ip, sizeof(ip));
+              snprintf(peer_str, sizeof(peer_str), "%s:%d", ip, ntohs(addr4->sin_port));
+            }
+          else if (peer_addr.ss_family == AF_INET6)
+            {
+              struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&peer_addr;
+              char ip[INET6_ADDRSTRLEN];
+              inet_ntop(AF_INET6, &addr6->sin6_addr, ip, sizeof(ip));
+              snprintf(peer_str, sizeof(peer_str), "[%s]:%d", ip, ntohs(addr6->sin6_port));
+            }
+          else
+            {
+              snprintf(peer_str, sizeof(peer_str), "<unknown family %d>", peer_addr.ss_family);
+            }
+          
+          snprintf(buf, buflen, " (fd %d: %s -> %s)",
+                   sock, local_str, peer_str);
+        }
+      else
+        {
+          // getpeername failed, socket might be disconnected
+          int err = errno;
+          snprintf(buf, buflen, " (fd %d: %s -> <disconnected: %s>)",
+                   sock, local_str, strerror(err));
+        }
+    }
+  else
+    {
+      // getsockname failed
+      int err = errno;
+      snprintf(buf, buflen, " (fd %d: <getsockname failed: %s>)", sock, strerror(err));
+    }
+#else
+  snprintf(buf, buflen, " (fd %d)", sock);
+#endif
+}
 
 /// Implement the send and receive functions, needed by the generic
 /// network pools layer.  See pool_net.[ch] for details.
@@ -110,17 +194,22 @@ ob_retort pool_tcp_send_nbytes (ob_sock_t sock, const void *buf, size_t len,
           // it's likely the other end closed the socket for some reason
           if (nwritten == -1 && erryes == EPIPE)
             {
+              char sock_info[256];
+              get_socket_info(sock, sock_info, sizeof(sock_info));
               OB_LOG_WARNING_CODE (0x20108027,
-                                   "socket was closed unexpectedly");
+                                   "socket was closed unexpectedly %s",
+                                   sock_info);
               pret = POOL_UNEXPECTED_CLOSE;
             }
           else
             {
+              char sock_info[256];
+              get_socket_info(sock, sock_info, sizeof(sock_info));
               OB_LOG_WARNING_CODE (0x20108000,
                                    "send() returned %" OB_FMT_SIZE "d with "
                                    "errno '%s' with %" OB_FMT_SIZE
-                                   "d bytes left\n",
-                                   nwritten, strerror (erryes), nleft);
+                                   "d bytes left %s\n",
+                                   nwritten, strerror (erryes), nleft, sock_info);
               pret = POOL_SEND_BADTH;
             }
           errno = erryes;
@@ -198,17 +287,22 @@ ob_retort pool_tcp_recv_nbytes (ob_sock_t sock, void *buf, size_t len,
           // it's likely the other end closed the socket for some reason
           if (nread == 0)
             {
+              char sock_info[256];
+              get_socket_info(sock, sock_info, sizeof(sock_info));
               OB_LOG_WARNING_CODE (0x20108028,
-                                   "socket was closed unexpectedly");
+                                   "socket was closed unexpectedly %s",
+                                   sock_info);
               pret = POOL_UNEXPECTED_CLOSE;
             }
           else
             {
+              char sock_info[256];
+              get_socket_info(sock, sock_info, sizeof(sock_info));
               OB_LOG_WARNING_CODE (0x20108001,
                                    "recv() returned %" OB_FMT_SIZE "d with "
                                    "errno '%s' with %" OB_FMT_SIZE
-                                   "d bytes left\n",
-                                   nread, strerror (erryes), nleft);
+                                   "d bytes left %s\n",
+                                   nread, strerror (erryes), nleft, sock_info);
               pret = POOL_RECV_BADTH;
             }
           errno = erryes;

--- a/libPlasma/c/pool_tcp.c
+++ b/libPlasma/c/pool_tcp.c
@@ -33,6 +33,11 @@
 #include <arpa/inet.h>
 #endif
 
+// Rate limiting for socket close warnings
+static ob_atomic_int64 last_close_warning_time = 0;
+static ob_atomic_int64 close_warning_count = 0;
+static const int64 WARNING_THROTTLE_MS = 5000;  // Only log every 5 seconds
+
 #ifdef _MSC_VER
 
 
@@ -194,11 +199,30 @@ ob_retort pool_tcp_send_nbytes (ob_sock_t sock, const void *buf, size_t len,
           // it's likely the other end closed the socket for some reason
           if (nwritten == -1 && erryes == EPIPE)
             {
-              char sock_info[256];
-              get_socket_info(sock, sock_info, sizeof(sock_info));
-              OB_LOG_WARNING_CODE (0x20108027,
-                                   "socket was closed unexpectedly %s",
-                                   sock_info);
+              ob_atomic_int64_add(&close_warning_count, 1);
+              int64 now = ob_current_time();
+              int64 last = ob_atomic_int64_read(&last_close_warning_time);
+              
+              if (now - last > WARNING_THROTTLE_MS * OB_MILLI_TIME)
+                {
+                  char sock_info[256];
+                  get_socket_info(sock, sock_info, sizeof(sock_info));
+                  int64 count = ob_atomic_int64_swap(&close_warning_count, 0);
+                  
+                  if (count > 1)
+                    {
+                      OB_LOG_WARNING_CODE (0x20108027,
+                                           "socket was closed unexpectedly %s (occurred %lld times in last %d seconds)",
+                                           sock_info, (long long)count, WARNING_THROTTLE_MS/1000);
+                    }
+                  else
+                    {
+                      OB_LOG_WARNING_CODE (0x20108027,
+                                           "socket was closed unexpectedly %s",
+                                           sock_info);
+                    }
+                  ob_atomic_int64_set(&last_close_warning_time, now);
+                }
               pret = POOL_UNEXPECTED_CLOSE;
             }
           else
@@ -287,11 +311,30 @@ ob_retort pool_tcp_recv_nbytes (ob_sock_t sock, void *buf, size_t len,
           // it's likely the other end closed the socket for some reason
           if (nread == 0)
             {
-              char sock_info[256];
-              get_socket_info(sock, sock_info, sizeof(sock_info));
-              OB_LOG_WARNING_CODE (0x20108028,
-                                   "socket was closed unexpectedly %s",
-                                   sock_info);
+              ob_atomic_int64_add(&close_warning_count, 1);
+              int64 now = ob_current_time();
+              int64 last = ob_atomic_int64_read(&last_close_warning_time);
+              
+              if (now - last > WARNING_THROTTLE_MS * OB_MILLI_TIME)
+                {
+                  char sock_info[256];
+                  get_socket_info(sock, sock_info, sizeof(sock_info));
+                  int64 count = ob_atomic_int64_swap(&close_warning_count, 0);
+                  
+                  if (count > 1)
+                    {
+                      OB_LOG_WARNING_CODE (0x20108028,
+                                           "socket was closed unexpectedly %s (occurred %lld times in last %d seconds)",
+                                           sock_info, (long long)count, WARNING_THROTTLE_MS/1000);
+                    }
+                  else
+                    {
+                      OB_LOG_WARNING_CODE (0x20108028,
+                                           "socket was closed unexpectedly %s",
+                                           sock_info);
+                    }
+                  ob_atomic_int64_set(&last_close_warning_time, now);
+                }
               pret = POOL_UNEXPECTED_CLOSE;
             }
           else

--- a/libPlasma/c/pool_tcp.c
+++ b/libPlasma/c/pool_tcp.c
@@ -34,9 +34,9 @@
 #endif
 
 // Rate limiting for socket close warnings
-static unt64 last_close_warning_time = 0;
+static float64 last_close_warning_time = 0;
 static unt64 close_warning_count = 0;
-static const unt64 WARNING_THROTTLE_MS = 5000 * OB_MILLI_TIME;  // 5 seconds
+static const float64 WARNING_THROTTLE_SECS = 5.0;  // 5 seconds
 
 #ifdef _MSC_VER
 
@@ -200,9 +200,9 @@ ob_retort pool_tcp_send_nbytes (ob_sock_t sock, const void *buf, size_t len,
           if (nwritten == -1 && erryes == EPIPE)
             {
               close_warning_count++;
-              unt64 now = ob_current_time();
+              float64 now = ob_current_time();
               
-              if (now - last_close_warning_time > WARNING_THROTTLE_MS)
+              if (now - last_close_warning_time > WARNING_THROTTLE_SECS)
                 {
                   char sock_info[256];
                   get_socket_info(sock, sock_info, sizeof(sock_info));
@@ -212,9 +212,9 @@ ob_retort pool_tcp_send_nbytes (ob_sock_t sock, const void *buf, size_t len,
                   if (count > 1)
                     {
                       OB_LOG_WARNING_CODE (0x20108027,
-                                           "socket was closed unexpectedly %s (occurred %llu times in last %d seconds)",
+                                           "socket was closed unexpectedly %s (occurred %llu times in last %.0f seconds)",
                                            sock_info, (unsigned long long)count, 
-                                           (int)(WARNING_THROTTLE_MS / OB_MILLI_TIME / 1000));
+                                           WARNING_THROTTLE_SECS);
                     }
                   else
                     {
@@ -313,9 +313,9 @@ ob_retort pool_tcp_recv_nbytes (ob_sock_t sock, void *buf, size_t len,
           if (nread == 0)
             {
               close_warning_count++;
-              unt64 now = ob_current_time();
+              float64 now = ob_current_time();
               
-              if (now - last_close_warning_time > WARNING_THROTTLE_MS)
+              if (now - last_close_warning_time > WARNING_THROTTLE_SECS)
                 {
                   char sock_info[256];
                   get_socket_info(sock, sock_info, sizeof(sock_info));
@@ -325,9 +325,9 @@ ob_retort pool_tcp_recv_nbytes (ob_sock_t sock, void *buf, size_t len,
                   if (count > 1)
                     {
                       OB_LOG_WARNING_CODE (0x20108028,
-                                           "socket was closed unexpectedly %s (occurred %llu times in last %d seconds)",
+                                           "socket was closed unexpectedly %s (occurred %llu times in last %.0f seconds)",
                                            sock_info, (unsigned long long)count,
-                                           (int)(WARNING_THROTTLE_MS / OB_MILLI_TIME / 1000));
+                                           WARNING_THROTTLE_SECS);
                     }
                   else
                     {

--- a/libPlasma/c/tests/MiscPoolTest.cpp
+++ b/libPlasma/c/tests/MiscPoolTest.cpp
@@ -8,6 +8,7 @@
 // and gtest provides a nice way to mush them into one file while
 // still keeping them logically separate.
 
+#include "plasma_config.h"
 #include "plasma-gtest-helpers.h"
 #include <gtest/gtest.h>
 #include <tests/ob-test-helpers.h>
@@ -28,6 +29,8 @@
 #include <set>
 #include <vector>
 #include <algorithm>
+
+#include <random>
 
 // Although pool_participate can take "participate options", we've never
 // tried giving it anything other than NULL.  This is understandable, since
@@ -324,7 +327,13 @@ TEST (MiscPoolTest, GangManipulation)
                                          cmd.create_options));
       sharks_slaw.push_back (pool_name);
     }
-  std::random_shuffle (jets_hoses.begin (), jets_hoses.end ());
+#ifdef HAVE_STD_SHUFFLE
+   std::shuffle(jets_hoses.begin(), jets_hoses.end(), std::mt19937{std::random_device{}()});
+#else
+   std::random_shuffle (jets_hoses.begin (), jets_hoses.end ());
+#endif
+
+
   for (int i = 0; i < 3; i++)
     {
       pool_hose ph = jets_hoses.back ();
@@ -343,7 +352,12 @@ TEST (MiscPoolTest, GangManipulation)
       EXPECT_TORTEQ (OB_OK, pool_join_gang (gang, ph));
     }
   EXPECT_EQ (5, pool_gang_count (gang));
+#ifdef HAVE_STD_SHUFFLE
+  std::shuffle(sharks_hoses.begin(), sharks_hoses.end(), std::mt19937{std::random_device{}()});
+#else
   std::random_shuffle (sharks_hoses.begin (), sharks_hoses.end ());
+#endif
+
   for (HoseVector::iterator it = sharks_hoses.begin ();
        it != sharks_hoses.end (); it++)
     {

--- a/plasma_config.h.in
+++ b/plasma_config.h.in
@@ -1,0 +1,37 @@
+/* plasma_config.h.in - Configuration header for Plasma library */
+
+#ifndef PLASMA_CONFIG_H
+#define PLASMA_CONFIG_H
+
+/* CMake will replace these with actual detection results */
+#cmakedefine HAVE_TCP_USER_TIMEOUT
+#cmakedefine HAVE_TCP_KEEPINTVL
+#cmakedefine HAVE_TCP_KEEPIDLE
+#cmakedefine HAVE_STD_MT19937
+#cmakedefine HAVE_STD_SHUFFLE
+#cmakedefine PLASMA_LEGACY_BUILD
+#cmakedefine PLASMA_ENABLE_TCP_OPTIMIZATIONS
+#cmakedefine PLASMA_ENABLE_LARGE_TRANSFER_LOGGING
+
+/* Network buffer sizes - adjusted based on build mode */
+#ifdef PLASMA_LEGACY_BUILD
+  #define PLASMA_TCP_BUFFER_SIZE (1024 * 1024)      /* 1MB for older systems */
+  #define PLASMA_TCP_TIMEOUT_MS 60000               /* 1 minute for older systems */
+#else
+  #define PLASMA_TCP_BUFFER_SIZE (16 * 1024 * 1024) /* 16MB for modern systems */
+  #define PLASMA_TCP_TIMEOUT_MS 300000              /* 5 minutes for modern systems */
+#endif
+
+/* Large transfer threshold for logging */
+#define PLASMA_LARGE_TRANSFER_THRESHOLD (1024 * 1024) /* 1MB */
+
+/* C++ standard detection */
+#if __cplusplus >= 201703L
+  #define PLASMA_HAS_CXX17 1
+#elif __cplusplus >= 201402L
+  #define PLASMA_HAS_CXX14 1
+#elif __cplusplus >= 201103L
+  #define PLASMA_HAS_CXX11 1
+#endif
+
+#endif /* PLASMA_CONFIG_H */


### PR DESCRIPTION
 - Add CMake options for legacy build support:
    - PLASMA_LEGACY_MODE: Forces C++11 and disables modern features
    - PLASMA_ENABLE_TCP_OPTIMIZATIONS: Controls TCP buffer/timeout settings
    - PLASMA_ENABLE_LARGE_TRANSFER_LOGGING: Controls transfer logging

  - Add automatic legacy mode detection:
    - GCC < 5.0 or Clang < 3.4 triggers legacy mode
    - PLASMA_LEGACY_BUILD environment variable forces legacy mode

  - Add plasma_config.h.in for feature detection:
    - Detects TCP_USER_TIMEOUT, TCP_KEEPINTVL, TCP_KEEPIDLE
    - Detects std::shuffle and std::mt19937 availability
    - Configures buffer sizes (1MB legacy, 16MB modern)
    - Configures timeouts (1min legacy, 5min modern)

  - Make TCP optimizations conditional:
    - Socket buffer settings only applied if enabled
    - TCP timeout features check for OS support
    - All optimizations wrapped in PLASMA_ENABLE_TCP_OPTIMIZATIONS

  - Make C++ modernizations conditional:
    - std::shuffle usage checks HAVE_STD_SHUFFLE
    - Falls back to std::random_shuffle in legacy mode
    - compat.h respects PLASMA_LEGACY_BUILD setting

  - Make logging conditional:
    - Large transfer logging checks PLASMA_ENABLE_LARGE_TRANSFER_LOGGING
    - Uses configurable PLASMA_LARGE_TRANSFER_THRESHOLD (1MB)