### PR TITLE
Allocate log codes and retorts for Haskell binding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,6 @@
 * Fix emscripten build.  Also, just generally be more correct in which
   header files we include in order to get `struct timeval`.
   [#2](https://github.com/plasma-hamper/plasma/pull/2)
+
+* Allocate log codes and retorts for Haskell binding.
+  [#12](https://github.com/plasma-hamper/plasma/pull/12)

--- a/libLoam/c/ob-log.h
+++ b/libLoam/c/ob-log.h
@@ -776,6 +776,7 @@ OB_LOAM_API ob_retort ob_log_add_rule (ob_log_level *lvl, ob_log_rule rul);
 // 0x87?????? = AVAILABLE
 // 0x88?????? = projects/video
 // 0x93?????? = projects/bgt                        (in mezzanine repo)
+// 0xA0?????? = hs-plasma
 
 // These are just for backwards compatibility.  There are better-named
 // macros above that do the same things.

--- a/libLoam/c/ob-retorts.h
+++ b/libLoam/c/ob-retorts.h
@@ -194,7 +194,15 @@ typedef int64 ob_retort;
 #define OB_RETORTS_TWILLIG2_LAST OB_CONST_RETORT (1599999)
 //@}
 
-// so add additional ranges for other libraries here, starting at 1600000
+/**
+ * hs-plasma
+ */
+//@{
+#define OB_RETORTS_HASKELL_FIRST OB_CONST_RETORT (1600000)
+#define OB_RETORTS_HASKELL_LAST  OB_CONST_RETORT (1699999)
+//@}
+
+// so add additional ranges for other libraries here, starting at 1700000
 
 /**
  * \cond INTERNAL


### PR DESCRIPTION
Add the constants `OB_RETORTS_HASKELL_FIRST` and `OB_RETORTS_HASKELL_LAST` to `ob-retorts.h`, and add a comment reserving `0xA0??????` in `ob-log.h`.