### PR TITLE
Include ASCII along with the hex bytes for rude data in `slaw_spew_overview()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,10 @@
 
 * Allocate log codes and retorts for Haskell binding.
   [#12](https://github.com/plasma-hamper/plasma/pull/12)
+
+* Change `slaw_spew_overview()` to display rude data as both hex and
+  ASCII, rather than just hex.  This is inspired by the format used by
+  the `hd(1)` command.  Additionally, a new libLoam function,
+  `ob_fmt_hex_line()` has been added, which implements this
+  functionality.
+  [#14](https://github.com/plasma-hamper/plasma/pull/14)

--- a/libLoam/c/ob-util.c
+++ b/libLoam/c/ob-util.c
@@ -411,3 +411,40 @@ void *ob_make_undefined (void *addr, size_t len)
 #endif
   return addr;
 }
+
+static const char hexdigs[16] = "0123456789abcdef";
+
+void ob_fmt_hex_line (char        dst[OB_HEX_LINE_LEN],
+                      const unt8 *src,
+                      size_t      srcLen)
+{
+  size_t hexIdx = 0;
+  size_t ascIdx = 50;
+  size_t i;
+
+  memset (dst, ' ', OB_HEX_LINE_LEN);
+  dst[ascIdx++] = '|';
+
+  for (i = 0; i < 16 && i < srcLen; i++)
+    {
+      const unt8 b  = src[i];
+      const unt8 lo = b & 0xf;
+      const unt8 hi = b >> 4;
+      char       c  = '.';
+
+      if (i == 8)
+        hexIdx++;
+
+      dst[hexIdx    ] = hexdigs[hi];
+      dst[hexIdx + 1] = hexdigs[lo];
+      hexIdx += 3;
+
+      if (b >= ' ' && b <= '~')
+        c = (char) b;
+
+      dst[ascIdx++] = c;
+    }
+
+  dst[ascIdx++] = '|';
+  dst[ascIdx  ] = 0;
+}

--- a/libLoam/c/ob-util.h
+++ b/libLoam/c/ob-util.h
@@ -149,6 +149,30 @@ OB_LOAM_API void *ob_make_undefined (void *addr, size_t len);
  */
 #define OB_INVALIDATE(x) ob_make_undefined ((void *) &(x), sizeof (x))
 
+/**
+ * Size of the array required by ob_fmt_hex_line().
+ *
+ * (68 characters, plus room for a terminating NUL character.)
+ */
+#define OB_HEX_LINE_LEN 69
+
+/**
+ * Formats up to 16 bytes from \a src as a line of hex plus ASCII,
+ * in the same format produced by the hd(1) command.  (Although not
+ * including the file offset that hd(1) puts at the beginning of the
+ * line.)  There are eight hex bytes, an additional space, another
+ * eight hex bytes, and then sixteen ASCII bytes, where bytes
+ * outside the ASCII range are represented with a period.
+ *
+ * The result is written into \a dst and terminated with a NUL
+ * character.
+ *
+ * If \a srcLen is greater than 16, it is treated as if it was 16.
+ */
+OB_LOAM_API void ob_fmt_hex_line (char        dst[OB_HEX_LINE_LEN],
+                                  const unt8 *src,
+                                  size_t      srcLen);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libPlasma/c/slaw.c
+++ b/libPlasma/c/slaw.c
@@ -2229,7 +2229,7 @@ static const slaw_handler ovew_handler = {NULL,
 
 #define _FW(...) func (whither, __VA_ARGS__)
 
-static void slaw_spew_numeric_ovewview (bslaw s, fwfunc func, FILE *whither)
+static void slaw_spew_numeric_ovewview (bslaw s, fwfunc func, void *whither)
 {
   int slinc =
     slaw_is_numeric_8 (s)
@@ -2306,7 +2306,7 @@ static void slaw_spew_internal (bslaw s, fwfunc func, void *whither,
       free (down);
     }
   else if (slaw_is_numeric (s))
-    slaw_spew_numeric_ovewview (s, func, (FILE *) whither);
+    slaw_spew_numeric_ovewview (s, func, whither);
   else if (slaw_is_list_or_map (s))
     {
       unt64 q, n = slaw_list_count (s);
@@ -2353,14 +2353,13 @@ static void slaw_spew_internal (bslaw s, fwfunc func, void *whither,
       if (rudeLen > 0)
         {
           int64 i;
-          _FW ("%srude data: %" OB_FMT_64 "d bytes", prolo, rudeLen);
-          for (i = 0; i < rudeLen; i++)
+          char  rudeBuf[OB_HEX_LINE_LEN];
+          _FW ("%srude data: %" OB_FMT_64 "d bytes\n", prolo, rudeLen);
+          for (i = 0; i < rudeLen; i += 16)
             {
-              if (i % 16 == 0)
-                _FW ("\n%s", prolo);
-              _FW (" %02x", rude[i]);
+              ob_fmt_hex_line (rudeBuf, rude + i, (size_t) (rudeLen - i));
+              _FW ("%s %s\n", prolo, rudeBuf);
             }
-          _FW ("\n");
         }
       _FW ("%s ))", prolo);
     }


### PR DESCRIPTION
Previously, `slaw_spew_overview()` formatted the rude data of a protein like this:

```
rude data: 129 bytes
 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52
 00 00 00 28 00 00 00 28 01 03 00 00 00 b6 30 2a
 2e 00 00 00 06 50 4c 54 45 00 00 00 ff ff ff a5
 d9 9f dd 00 00 00 36 49 44 41 54 08 d7 63 60 c0
 01 f8 ff ff ff ff 81 68 f2 00 12 89 10 3f 0c 26
 1b c1 24 03 88 fc c7 50 8f 95 84 c8 42 55 1e c6
 30 ff 39 92 38 7e f2 39 5c 17 0e 00 00 90 16 74
 17 5c 70 86 58 00 00 00 00 49 45 4e 44 ae 42 60
 82
```

This pull request changes it to do this instead.

```
rude data: 129 bytes
 89 50 4e 47 0d 0a 1a 0a  00 00 00 0d 49 48 44 52  |.PNG........IHDR|
 00 00 00 28 00 00 00 28  01 03 00 00 00 b6 30 2a  |...(...(......0*|
 2e 00 00 00 06 50 4c 54  45 00 00 00 ff ff ff a5  |.....PLTE.......|
 d9 9f dd 00 00 00 36 49  44 41 54 08 d7 63 60 c0  |......6IDAT..c`.|
 01 f8 ff ff ff ff 81 68  f2 00 12 89 10 3f 0c 26  |.......h.....?.&|
 1b c1 24 03 88 fc c7 50  8f 95 84 c8 42 55 1e c6  |..$....P....BU..|
 30 ff 39 92 38 7e f2 39  5c 17 0e 00 00 90 16 74  |0.9.8~.9\......t|
 17 5c 70 86 58 00 00 00  00 49 45 4e 44 ae 42 60  |.\p.X....IEND.B`|
 82                                                |.|
```

This format is modeled after the output of the `hd(1)` command.

In addition to changing the behavior of `slaw_spew_overview()`, this pull request also adds a new function `ob_fmt_hex_line()` to `ob-util.h` in libLoam.  This is where the formatting is implemented, and the function is exposed so that other code that wants to use a similar format can do so.