### PR TITLE
fix cmake std::shuffle detection when compiler defaults to < C++-11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,18 +156,22 @@ check_cxx_source_compiles("
     #include <random>
     #include <algorithm>
     #include <vector>
-    int main() { 
-        std::vector<int> v = {1,2,3,4,5};
+    int main () {
+        // std::vector<int> v = {1,2,3,4,5};  // cain't when compiling < c++-11
+        std::vector <int> v;
+        v.push_back (1);  v.push_back (2);
+        v.push_back (3);  v.push_back (4);
+        v.push_back (5);
         std::mt19937 gen;
-        std::shuffle(v.begin(), v.end(), gen);
-        return 0; 
+        std::shuffle (v.begin (), v.end (), gen);
+        return 0;
     }" HAVE_STD_SHUFFLE)
 
 check_cxx_source_compiles("
     #include <random>
-    int main() { 
+    int main() {
         std::mt19937 gen;
-        return 0; 
+        return 0;
     }" HAVE_STD_MT19937)
 
 # Check for TCP features
@@ -178,7 +182,7 @@ if(NOT WIN32)
 endif()
 
 # Configure plasma_config.h
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plasma_config.h.in 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plasma_config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/plasma_config.h)
 if (UNIX)
   set(OPENSSL_LIBRARIES "-lssl -lcrypto")
@@ -303,7 +307,7 @@ if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_USE_MATH_DEFINES" )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /showIncludes")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /showIncludes")
-     
+
     # binary location differs with generator
     if (WIN32 AND NOT CMAKE_GENERATOR MATCHES Ninja)
         set(BIN_SUBDIR ${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
CMakeLists.txt uses cmake's "check_cxx_source_compiles()" facility to determine whether e.g. std::shuffle() is available; the test tries to compile a program that references the function in question, and if it succeeds then that function is known to be available. The attempted compilation uses whatever version of C++ is the underlying compiler's default, however -- irrespective of the C++ version that'll be used for the actual compile that cmake is setting up for (!) -- and on OSX 12's clang-version-13 the default C++ is not even C++-11 (you'll find the __cplusplus macro set to 199711L) and so the test code (as added in commit 418d4147), which includes the line
      std::vector<int> v = {1,2,3,4,5};
, does not compile... but if fails to compile because of the initializer-list style that only appears with C++-11 (whereas the line that exercises std::shuffle() does not result in an error). Nonetheless, since the compiler test fails, std::shuffle is marked as unavailable.

This patch primitivizes the C++ use (simply by declaring the variable v first and then filling it via repeated application of push_back()), and so now the test accurately detects the presence or absence of std:shuffle().

Really, we could just excise the initializer-list part of the code and live out our test-compiley life with an empty vector, but it is not the place of this patch to alter the sense or intent of the code it patches.