### PR TITLE
Fix two fatal cmake errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ STRING(REPLACE ";" " " ICU_LIBRARIES_SPACE_SEP "${ICU_LIBRARIES}" )
 # otherwise boost includes optimized and debug versions, which fouls up the build
 set(Boost_USE_DEBUG_RUNTIME FALSE)
 set(BOOST_ROOT ${YOBUILD})
-find_package(Boost REQUIRED COMPONENTS filesystem regex system)
+find_package(Boost REQUIRED COMPONENTS filesystem regex)
 if (NOT WIN32)
     # Using absolute paths to libraries causes great woe in .pc files
     # Instead, use -l flags.   We already have all needed -L and -I flags.

--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 # ${gtest_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
 project(gtest CXX C)
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.6.2)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-suggest-override")

--- a/libPlasma/c/CMakeLists.txt
+++ b/libPlasma/c/CMakeLists.txt
@@ -1,6 +1,6 @@
 # /* (c) 2010 Oblong Industries */
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.6.2)
 project(Plasma)
 
 # Avoid cmake warnings on Mac

--- a/libPlasma/ruby/CMakeLists.txt
+++ b/libPlasma/ruby/CMakeLists.txt
@@ -1,6 +1,6 @@
 # /* (c) 2014 Oblong Industries */
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.6.2)
 project(rubyPlasma)
 
 # Avoid cmake warnings on Mac

--- a/libPlasma/zeroconf/CMakeLists.txt
+++ b/libPlasma/zeroconf/CMakeLists.txt
@@ -1,6 +1,6 @@
 # /* (c) 2014 Oblong Industries */
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.6.2)
 project(PlasmaZeroconf)
 
 # Avoid cmake warnings on Mac


### PR DESCRIPTION
A clone was not building on my Mac. I removed Boost.System and updated minimum versions, and now it builds.

See the commit messages for more details.