### PR TITLE
Replace all remaining uses of sprintf() with snprintf()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,6 @@
 * Fix small memory leak on non-glibc (effectively, non-Linux)
   platforms.
   [#20](https://github.com/plasma-hamper/plasma/pull/20)
+
+* Replace uses of `sprintf()` with `snprintf()` instead.
+  [#22](https://github.com/plasma-hamper/plasma/pull/22)

--- a/libLoam/c/ob-util.c
+++ b/libLoam/c/ob-util.c
@@ -361,10 +361,11 @@ ob_retort ob_append_env_list (const char *name, const char *value)
   if (!oldval)
     return ob_setenv (name, value);
 
-  char *buf = malloc (strlen (value) + 1 + strlen (oldval) + 1);
+  size_t buf_len = strlen (value) + 1 + strlen (oldval) + 1;
+  char *buf = malloc (buf_len);
   if (!buf)
     return OB_NO_MEM;
-  sprintf (buf, "%s%c%s", oldval, OB_PATH_CHAR, value);
+  snprintf (buf, buf_len, "%s%c%s", oldval, OB_PATH_CHAR, value);
 
   err = ob_setenv (name, buf);
   free (buf);
@@ -378,10 +379,11 @@ ob_retort ob_prepend_env_list (const char *name, const char *value)
   if (!oldval)
     return ob_setenv (name, value);
 
-  char *buf = malloc (strlen (value) + 1 + strlen (oldval) + 1);
+  size_t buf_len = strlen (value) + 1 + strlen (oldval) + 1;
+  char *buf = malloc (buf_len);
   if (!buf)
     return OB_NO_MEM;
-  sprintf (buf, "%s%c%s", value, OB_PATH_CHAR, oldval);
+  snprintf (buf, buf_len, "%s%c%s", value, OB_PATH_CHAR, oldval);
 
   err = ob_setenv (name, buf);
   free (buf);

--- a/libLoam/c/tests/test-env.c
+++ b/libLoam/c/tests/test-env.c
@@ -33,7 +33,8 @@ void test_ob_append_env_list (void)
   val = getenv ("BLARG");
   if (!val)
     error_exit ("getenv failed");
-  sprintf (expected, "%s%c%s", "/dir1", OB_PATH_CHAR, "/dir2");
+  snprintf (expected, sizeof (expected),
+            "%s%c%s", "/dir1", OB_PATH_CHAR, "/dir2");
   if (strcmp (val, expected))
     error_exit ("ob_append_env_list wrong value");
 
@@ -44,8 +45,10 @@ void test_ob_append_env_list (void)
   val = getenv ("BLARG");
   if (!val)
     error_exit ("getenv failed");
-  sprintf (expected, "%s%c%s%c%s", "/dir0", OB_PATH_CHAR, "/dir1", OB_PATH_CHAR,
-           "/dir2");
+  snprintf (expected, sizeof (expected), "%s%c%s%c%s",
+            "/dir0", OB_PATH_CHAR,
+            "/dir1", OB_PATH_CHAR,
+            "/dir2");
   if (strcmp (val, expected))
     error_exit ("ob_prepend_env_list wrong value");
 }

--- a/tests/ob-test-helpers.h
+++ b/tests/ob-test-helpers.h
@@ -14,10 +14,11 @@
  * even in out-of-tree builds.
  * buf must be a buffer big enough to hold the path.
  */
-static char *ob_test_source_relative3 (const char *abssrcdir, const char *fname,
-                                       char *buf)
+static char *ob_test_source_relative3 (const char *abssrcdir,
+                                       const char *fname,
+                                       char *buf, size_t buf_len)
 {
-  sprintf (buf, "%s/%s", abssrcdir, fname);
+  snprintf (buf, buf_len, "%s/%s", abssrcdir, fname);
   return buf;
 }
 
@@ -33,7 +34,9 @@ static char ob_find_file_name_buf[2048];
 static const char *ob_test_source_relative2 (const char *abssrcdir,
                                              const char *fname)
 {
-  return ob_test_source_relative3 (abssrcdir, fname, ob_find_file_name_buf);
+  return ob_test_source_relative3 (abssrcdir, fname,
+                                   ob_find_file_name_buf,
+                                   sizeof (ob_find_file_name_buf));
 }
 
 /* Read a file with a path relative to the top of the source tree


### PR DESCRIPTION
We should not be using `sprintf()` in 2026.  (We shouldn't have been using it in 2009, for that matter.)

Although I've scrubbed `sprintf()` out of the codebase periodically, it looks like a few instances have crept back in.  This commit replaces them with `snprintf()`, as they should be.
