### PR TITLE
Fix (most) tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,3 +139,12 @@
 
 * When running CMake, summarize which optional libraries were found.
   [#24](https://github.com/plasma-hamper/plasma/pull/24)
+
+* Fix a bug in getting string descriptions for retorts.
+  [#25](https://github.com/plasma-hamper/plasma/pull/25)
+
+* Update Ruby test code to work with minitest gem ≥ 5.0.
+  [#25](https://github.com/plasma-hamper/plasma/pull/25)
+
+* Fix bugs in `spew-test`, `aptest3`, and `diffGitStatusTest`.
+  [#25](https://github.com/plasma-hamper/plasma/pull/25)

--- a/README.md
+++ b/README.md
@@ -138,3 +138,13 @@ sudo mkdir /opt/plasma
 sudo chown -R `id -u`:`id -g` /opt/plasma
 ninja install
 ```
+
+## Tests
+
+Currently, the following invocation should pass:
+
+```
+YT_ONLY_FIXTURES="local;tcp;tcpo" ctest --progress -E spew-test
+```
+
+For more information about running tests, see [TESTS.md](TESTS.md).

--- a/bld/cmake/CMakeLists.txt
+++ b/bld/cmake/CMakeLists.txt
@@ -39,8 +39,7 @@ IF(EXISTS "${g-speak_SOURCE_DIR}/.git/config")
   # .gitignore.
   add_test(
     NAME diffGitStatusTest
-    COMMAND "${SHELL}" "${g-speak_SOURCE_DIR}/bld/cmake/diff-git-status-test.sh" "test" "${g-speak_BINARY_DIR}"
+    COMMAND "${g-speak_SOURCE_DIR}/bld/cmake/diff-git-status-test.sh" "test" "${g-speak_BINARY_DIR}"
     WORKING_DIRECTORY "${g-speak_SOURCE_DIR}"
   )
 ENDIF()
-

--- a/libLoam/c++/tests/aptest3.rb
+++ b/libLoam/c++/tests/aptest3.rb
@@ -17,7 +17,7 @@ end
 ecode, actual = obbacktick("aptest3 -h")
 
 expected = Regexp.new(<<'DONE', Regexp::MULTILINE)
-\Ag-speak SOE \(c\) Oblong Industries - g-speak .+
+\Aplasma \(c\) Oblong Industries and ANIMIST contributors - plasma .+
 Usage: aptest3.* \[options\]\s*
 The wjc gstreamer plugin will select defaults for options left unspecified\.
   -h, --help         print this help, then exit

--- a/libLoam/c/ob-retorts.c
+++ b/libLoam/c/ob-retorts.c
@@ -87,9 +87,12 @@ const char *ob_error_string_literal (ob_retort err)
       default:
         // See if this was an errno wrapped in a retort
         e = ob_retort_to_errno (err);
-	const char *s = strerror(e);
-	if (s)
-	  return s;
+        if (e > 0)
+          {
+            const char *s = strerror(e);
+            if (s)
+              return s;
+          }
         // if (e > 0 && e < NERR)
         //   {
         //     const char *s = ERRLIST[e];

--- a/libLoam/c/tests/test-helpers.rb
+++ b/libLoam/c/tests/test-helpers.rb
@@ -3,8 +3,8 @@
 # test/unit went away in Ruby 2.0, but we still need to build on ruby 1.x
 begin
   require 'minitest/autorun'
-  Test = MiniTest
-  module MiniTest
+  Test = Minitest
+  module Minitest
     # Allow assert_not_nil, even though it's obsolete
     module Assertions
       alias assert_not_nil refute_nil
@@ -12,8 +12,9 @@ begin
   end
 rescue LoadError
   require 'test/unit'
-  MiniTest = Test
+  Minitest = Test
   module Test
+    Test = Unit::TestCase
     Assertions = Unit::Assertions
     # Allow refute_nil, even though it's from the future
     module Assertions

--- a/libLoam/c/tests/test-obversion.rb
+++ b/libLoam/c/tests/test-obversion.rb
@@ -86,7 +86,7 @@ LSBRP = '/usr/bin/lsb_release' # for Linux
 SV = '/usr/bin/sw_vers' # for Mac OS X
 CPUINFO = '/proc/cpuinfo' # for Linux
 
-class ObVersionTest < Test::Unit::TestCase
+class ObVersionTest < Minitest::Test
   if HAVE_JSON
     def test_yaml_json_equal
       unjson = JSON.load($vers_data)

--- a/libPlasma/c/t/CMakeLists.txt
+++ b/libPlasma/c/t/CMakeLists.txt
@@ -57,9 +57,8 @@ generate_tests("${PlasmaT_TESTS}" "${PlasmaT_LINK_LIBS}")
 
 # spew-test depends on ICU, so only build it when ICU is available.
 if(ICU_LIBRARIES AND BUILD_TESTS)
-    add_executable(spew-test spew-test.c)
-    target_link_libraries(spew-test gtest gtest_main ${PlasmaT_LINK_LIBS} ${ICU_LIBRARIES})
-    add_wrapped_test(spew-test spew-test "local")
+  set(SpewTest_LINK_LIBS ${PlasmaT_LINK_LIBS} ${ICU_LIBRARIES})
+  generate_tests("spew-test" "${SpewTest_LINK_LIBS}")
 endif()
 
 # Test programs needed by the scripts in the above list (and not already

--- a/libPlasma/ruby/bug3787.rb
+++ b/libPlasma/ruby/bug3787.rb
@@ -24,7 +24,7 @@ def after_depositing
   end
 end
 
-class PoolTest < Test::Unit::TestCase
+class PoolTest < Minitest::Test
   def test_3787
     after_depositing do | hose |
       2048.times do

--- a/libPlasma/ruby/file-io-test.rb
+++ b/libPlasma/ruby/file-io-test.rb
@@ -7,7 +7,7 @@ include Plasma
 
 FNAME =  "scratch/slaw-out-test.slawx"
 
-class FileIOTest < Test::Unit::TestCase
+class FileIOTest < Minitest::Test
   # Old Test::Unit ran classes in alphabetical order.
   # New Minitest::Unit runs classes and cases in random order by default.
   # It's hard to be portable between the two.

--- a/libPlasma/ruby/hose-extension-tests.rb
+++ b/libPlasma/ruby/hose-extension-tests.rb
@@ -134,7 +134,7 @@ class TimeCognizantAwaiter < GangBasicAwaiter
 end
 
 
-class TimePseudoHoseTest < Test::Unit::TestCase
+class TimePseudoHoseTest < Minitest::Test
 
   def setup
     @feeders = Array.new

--- a/libPlasma/ruby/json-tests.rb
+++ b/libPlasma/ruby/json-tests.rb
@@ -123,7 +123,7 @@ END
 
 JSON.create_id = "¿json class?"
 
-class SlawTest < Test::Unit::TestCase
+class SlawTest < Minitest::Test
 
   def test_cons
     j = Slaw.from_yaml(KATE_EXAMPLE).to_json

--- a/libPlasma/ruby/pool-tests.rb
+++ b/libPlasma/ruby/pool-tests.rb
@@ -26,7 +26,7 @@ def my_list_pools
   end
 end
 
-class PoolTest < Test::Unit::TestCase
+class PoolTest < Minitest::Test
 
   def setup
     @feeders = Array.new

--- a/libPlasma/ruby/slaw-tests.rb
+++ b/libPlasma/ruby/slaw-tests.rb
@@ -237,7 +237,7 @@ RUDE_EXAMPLE = <<'END'
 rude_data: !!binary wAHQDQ==
 END
 
-class SlawTest < Test::Unit::TestCase
+class SlawTest < Minitest::Test
 
   def test_nested_slaw_in_list
     s = Slaw.new( [1,

--- a/libPlasma/ruby/test-helpers.rb
+++ b/libPlasma/ruby/test-helpers.rb
@@ -6,8 +6,8 @@ require 'rbconfig'
 # test/unit went away in Ruby 2.0, but we still need to build on ruby 1.x
 begin
   require 'minitest/autorun'
-  Test = MiniTest
-  module MiniTest
+  Test = Minitest
+  module Minitest
     # Allow assert_not_nil, even though it's obsolete
     module Assertions
       alias assert_not_nil refute_nil
@@ -15,8 +15,9 @@ begin
   end
 rescue LoadError
   require 'test/unit'
-  MiniTest = Test
+  Minitest = Test
   module Test
+    Test = Unit::TestCase
     Assertions = Unit::Assertions
     # Allow refute_nil, even though it's from the future
     module Assertions

--- a/libPlasma/ruby/types-test.rb
+++ b/libPlasma/ruby/types-test.rb
@@ -282,7 +282,7 @@ end
 # test loops for numeric types
 #
 
-class PoolTypesTest < Test::Unit::TestCase
+class PoolTypesTest < Minitest::Test
   def test_all_basic_types
     h = Pool.participate( PNAME );
     h.rewind


### PR DESCRIPTION
Fix most tests so that they pass now.

With these fixes applied, the following invocation should pass:

```
YT_ONLY_FIXTURES="local;tcp;tcpo" ctest --progress -E spew-test
```

There are two classes of failures that remain to be fixed:

* `spew-test` fails because the output does not match expected.  This is due to changes in how "rude data" is displayed.  I will fix this in a subsequent pull request.

* TLS with certificates (fixure "tcps") currently fails because the certificates have expired.  I need to figure out how to regenerate the certificates, and do that.